### PR TITLE
chore(vercel): add README with Vercel deploy steps and make UI Vercel-ready

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
+.next/
 .env.local
+.vercel/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+## Deploy on Vercel
+
+1. Go to https://vercel.com → **New Project** → Import this GitHub repo.
+2. Framework Preset: **Next.js** (auto-detected).
+3. Set Environment Variables:
+   - `API_BASE` = `https://<your-backend-host>:8000` (or staging URL)
+   - `API_KEY`  = `<your-key>`
+4. Click **Deploy**. Every push to `main` auto-deploys.
+
+### Local Dev
+```bash
+cp .env.example .env.local
+# update API_BASE, API_KEY as needed
+npm install
+npm run dev
+# open http://localhost:3000

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "RAG_Admin_UI",
   "private": true,
   "scripts": {
-    "dev": "npx http-server -p 5173 -c- ."
+    "dev": "npx http-server -p 5173 -c- .",
+    "build": "next build",
+    "start": "next start"
   },
   "dependencies": {
     "dayjs": "^1.11.15",

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,9 @@
+export default function Home() {
+  return (
+    <div style={{ padding: 24 }}>
+      <h1>RAG Admin UI</h1>
+      <p>Welcome! Use the uploader to submit documents.</p>
+      <a href="/upload">Go to Upload</a>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Adds a README and makes the repo Vercel-ready:
- New README with “Deploy on Vercel” steps
- Ensures env example (`API_BASE`, `API_KEY`) is documented
- (Optional) simple Home page linking to `/upload`
- Standard Node/Next ignores in `.gitignore`

## Why
Phase 2 milestone mentions Vercel hosting. This PR makes it easy to connect the GitHub repo to Vercel and deploy.

## Next
- Connect repo in Vercel and set env vars:
  - `API_BASE` = <backend API base URL>
  - `API_KEY`  = <key>
- Share live URL for SME testing
- Next UI task: basic documents list view calling `/documents?user_id=...`
